### PR TITLE
Exclude Non-Shinies

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,6 +23,7 @@ $shinyStats = $db->select('pokemon_shiny_stats', [
     'count' => Medoo::raw('SUM(`count`)')
 ], [
     'date' => $today,
+    'count[>]' => 0,
     'GROUP' => 'pokemon_id'
 ]);
 


### PR DESCRIPTION
Thanks to @plinytheelder 

One of the changes to Golbat has caused non-shinies to show:
![image](https://github.com/versx/ShinyStatsPHP/assets/80601216/cfa5a05b-8ef8-4467-bf16-959e036c955e)

This PR is a simple fix to exclude them.